### PR TITLE
Fix a test name and add two open content edge cases

### DIFF
--- a/ion_schema_2_0/constraints/contains.isl
+++ b/ion_schema_2_0/constraints/contains.isl
@@ -77,7 +77,7 @@ $test::{
 }
 
 type::{
-  name: contains_with_duplicate_elements,
+  name: contains_with_duplicated_value,
   contains: [1, 1],
 }
 

--- a/ion_schema_2_0/open_content/top_level_user_content.isl
+++ b/ion_schema_2_0/open_content/top_level_user_content.isl
@@ -51,6 +51,8 @@ $test::{
   description: "Any type of Ion value can be top-level open content",
   valid_schemas:[
     ( $ion_schema_2_0 null ),
+    ( $ion_schema_2_0 null.symbol ),
+    ( $ion_schema_2_0 null.struct ),
     ( $ion_schema_2_0 true ),
     ( $ion_schema_2_0 2000 ),
     ( $ion_schema_2_0 3000e0 ),


### PR DESCRIPTION
### Issue #, if available:

None

### Description of changes:

* Fixes a test name and type name that doesn't match
* Adds `null.struct` and `null.symbol` to open content tests to make sure that ISL top-level struct (type, header, footer) logic and ISL version marker logic handle nulls correctly.
----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
