### PR TITLE
Fix user_reserved_fields test cases and mark import test cases that cannot be detected by ion-schema-schemas

### DIFF
--- a/ion_schema_2_0/imports/diamond/header_import_a.isl
+++ b/ion_schema_2_0/imports/diamond/header_import_a.isl
@@ -41,6 +41,7 @@ schema_footer::{}
 
 $test::{
   description: "no indirectly imported types should be available in this schema's scope",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { type: d_type, },
   ]

--- a/ion_schema_2_0/imports/diamond/inline_import_a.isl
+++ b/ion_schema_2_0/imports/diamond/inline_import_a.isl
@@ -32,6 +32,7 @@ $test::{
 
 $test::{
   description: "no imported types should be available in this schema's scope",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { type: b_type, },
     { type: c_type, },

--- a/ion_schema_2_0/imports/header_imports.isl
+++ b/ion_schema_2_0/imports/header_imports.isl
@@ -139,6 +139,7 @@ $test::{
 
 $test::{
   description: "A schema should not be able to reference an aliased type by its original name",
+  isl_for_isl_can_validate: false,
   invalid_schemas: [
     (
       $ion_schema_2_0
@@ -211,6 +212,7 @@ $test::{
 
 $test::{
   description: "Two different imported types with the same name or alias should result in an error",
+  isl_for_isl_can_validate: false,
   invalid_schemas: [
     (
       $ion_schema_2_0
@@ -237,6 +239,7 @@ $test::{
 
 $test::{
   description: "Importing a type with the same name or alias as locally defined type should result in an error",
+  isl_for_isl_can_validate: false,
   invalid_schemas: [
     (
       // Name conflict from schema import

--- a/ion_schema_2_0/imports/invalid_imports.isl
+++ b/ion_schema_2_0/imports/invalid_imports.isl
@@ -235,6 +235,7 @@ $test::{
 
 $test::{
   description: "when imported schema or type does not exist, should be an invalid schema",
+  isl_for_isl_can_validate: false,
   invalid_schemas: [
     (
       $ion_schema_2_0

--- a/ion_schema_2_0/imports/tree/header_import_a.isl
+++ b/ion_schema_2_0/imports/tree/header_import_a.isl
@@ -42,6 +42,7 @@ schema_footer::{}
 
 $test::{
   description: "no indirectly imported types should be available in this schema's scope",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { type: d_type, },
     { type: e_type, },

--- a/ion_schema_2_0/imports/tree/inline_import_a.isl
+++ b/ion_schema_2_0/imports/tree/inline_import_a.isl
@@ -33,6 +33,7 @@ $test::{
 
 $test::{
   description: "no imported types should be available in this schema's scope",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { type: b_type, },
     { type: c_type, },

--- a/ion_schema_2_0/open_content/user_fields_declaration.isl
+++ b/ion_schema_2_0/open_content/user_fields_declaration.isl
@@ -32,27 +32,33 @@ $test::{
     (
       $ion_schema_2_0
       schema_header::{
-        type: [a, b, c],
-        // 'foo' is not one of the allowed fields in the user_reserved_fields struct
-        foo: [d, e, f],
+        user_reserved_fields: {
+          type: [ a, b, c ],
+          // 'foo' is not one of the allowed fields in the user_reserved_fields struct
+          foo: [ d, e, f ],
+        }
       }
       schema_footer::{}
     ),
     (
       $ion_schema_2_0
       schema_header::{
-        type: [a, b, c],
-        // Not even unreserved field names.
-        $Foo: [d, e, f],
+        user_reserved_fields: {
+          type: [a, b, c],
+          // Not even unreserved field names.
+          $Foo: [d, e, f],
+        }
       }
       schema_footer::{}
     ),
     (
       $ion_schema_2_0
       schema_header::{
-        type: [a, b, c],
-        // Unexpected repetition of the field name
-        type: [d, e, f],
+        user_reserved_fields: {
+          type: [a, b, c],
+          // Unexpected repetition of the field name
+          type: [d, e, f],
+        }
       }
       schema_footer::{}
     ),


### PR DESCRIPTION

### Issue #, if available:

None

### Description of changes:

* Some test cases for user_reserved_fields were passing, but for the wrong reason. They were testing to make sure that certain prohibited fields would cause the schema to be invalid, but the test data was already invalid _in a different way_. This commit fixes those test cases.
* Some test cases that require resolving imports cannot be detected as invalid by Ion Schema Schemas, so I have added the flag to indicate that.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
