### PR TITLE
Adds tests for cyclical imports for Ion Schema 1.0

### DIFF
--- a/ion_schema_1_0/schema/import/cycles/header_import_a.isl
+++ b/ion_schema_1_0/schema/import/cycles/header_import_a.isl
@@ -1,0 +1,20 @@
+schema_header::{
+  imports: [
+    { id: "schema/import/cycles/header_import_b.isl" }
+  ]
+}
+
+type::{
+  name: list_of_structs,
+  type: list,
+  element: struct_of_lists,
+}
+
+$test::{
+  type: list_of_structs,
+  should_accept_as_valid: [
+    [],
+    [{a:[]}],
+  ],
+}
+schema_footer::{}

--- a/ion_schema_1_0/schema/import/cycles/header_import_b.isl
+++ b/ion_schema_1_0/schema/import/cycles/header_import_b.isl
@@ -1,0 +1,21 @@
+schema_header::{
+  imports: [
+    { id: "schema/import/cycles/header_import_a.isl" }
+  ]
+}
+
+type::{
+  name: struct_of_lists,
+  type: struct,
+  element: list_of_structs
+}
+
+$test::{
+  type: struct_of_lists,
+  should_accept_as_valid: [
+    {},
+    { a: [{}] },
+  ],
+}
+
+schema_footer::{}

--- a/ion_schema_1_0/schema/import/cycles/header_import_by_type_a.isl
+++ b/ion_schema_1_0/schema/import/cycles/header_import_by_type_a.isl
@@ -1,0 +1,20 @@
+schema_header::{
+  imports: [
+    { id: "schema/import/cycles/header_import_by_type_b.isl", type: struct_of_lists }
+  ]
+}
+
+type::{
+  name: list_of_structs,
+  type: list,
+  element: struct_of_lists,
+}
+
+$test::{
+  type: list_of_structs,
+  should_accept_as_valid: [
+    [],
+    [{a:[]}],
+  ],
+}
+schema_footer::{}

--- a/ion_schema_1_0/schema/import/cycles/header_import_by_type_b.isl
+++ b/ion_schema_1_0/schema/import/cycles/header_import_by_type_b.isl
@@ -1,0 +1,21 @@
+schema_header::{
+  imports: [
+    { id: "schema/import/cycles/header_import_by_type_a.isl", type: list_of_structs }
+  ]
+}
+
+type::{
+  name: struct_of_lists,
+  type: struct,
+  element: list_of_structs
+}
+
+$test::{
+  type: struct_of_lists,
+  should_accept_as_valid: [
+    {},
+    { a: [{}] },
+  ],
+}
+
+schema_footer::{}

--- a/ion_schema_1_0/schema/import/cycles/header_import_by_type_with_alias_a.isl
+++ b/ion_schema_1_0/schema/import/cycles/header_import_by_type_with_alias_a.isl
@@ -1,0 +1,20 @@
+schema_header::{
+  imports: [
+    { id: "schema/import/cycles/header_import_by_type_b.isl", type: struct_of_lists, as: foo }
+  ]
+}
+
+type::{
+  name: list_of_structs,
+  type: list,
+  element: foo,
+}
+
+$test::{
+  type: list_of_structs,
+  should_accept_as_valid: [
+    [],
+    [{a:[]}],
+  ],
+}
+schema_footer::{}

--- a/ion_schema_1_0/schema/import/cycles/header_import_by_type_with_alias_b.isl
+++ b/ion_schema_1_0/schema/import/cycles/header_import_by_type_with_alias_b.isl
@@ -1,0 +1,21 @@
+schema_header::{
+  imports: [
+    { id: "schema/import/cycles/header_import_by_type_a.isl", type: list_of_structs, as: foo }
+  ]
+}
+
+type::{
+  name: struct_of_lists,
+  type: struct,
+  element: foo
+}
+
+$test::{
+  type: struct_of_lists,
+  should_accept_as_valid: [
+    {},
+    { a: [{}] },
+  ],
+}
+
+schema_footer::{}

--- a/ion_schema_1_0/schema/import/cycles/inline_import_a.isl
+++ b/ion_schema_1_0/schema/import/cycles/inline_import_a.isl
@@ -1,0 +1,13 @@
+type::{
+  name: list_of_structs,
+  type: list,
+  element: { id: "schema/import/cycles/inline_import_b.isl", type: struct_of_lists },
+}
+
+$test::{
+  type: list_of_structs,
+  should_accept_as_valid: [
+    [],
+    [{a:[]}],
+  ],
+}

--- a/ion_schema_1_0/schema/import/cycles/inline_import_b.isl
+++ b/ion_schema_1_0/schema/import/cycles/inline_import_b.isl
@@ -1,0 +1,13 @@
+type::{
+  name: struct_of_lists,
+  type: struct,
+  element: { id: "schema/import/cycles/inline_import_a.isl", type: list_of_structs }
+}
+
+$test::{
+  type: struct_of_lists,
+  should_accept_as_valid: [
+    {},
+    { a: [{}] },
+  ],
+}


### PR DESCRIPTION
### Issue #, if available:

None

### Description of changes:

Adds tests for import cycles to the Ion Schema 1.0 test suite. They are basically a copy/paste of the equivalent tests for Ion Schema 2.0, with the ISL 2.0 version marker removed and the import paths updated accordingly.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
