### PR TITLE
Updates version marker, header, and footer tests for amazon-ion/ion-schema#118

### DIFF
--- a/ion_schema_2_0/schema/ion_schema_version_markers.isl
+++ b/ion_schema_2_0/schema/ion_schema_version_markers.isl
@@ -23,15 +23,6 @@ $test::{
     ),
     (
       $ion_schema_2_0
-      header::{}
-      type::{
-        name: foo
-      }
-      footer::{}
-      $ion_schema_2_0
-    ),
-    (
-      $ion_schema_2_0
       type::{
         name: foo
       }
@@ -47,17 +38,19 @@ $test::{
   invalid_schemas:[
     (
       $ion_schema_0_1
+      schema_header::{}
       type::{
         name: foo
       }
-      footer::{}
+      schema_footer::{}
     ),
     (
       $ion_schema_2_x
+      schema_header::{}
       type::{
         name: foo
       }
-      footer::{}
+      schema_footer::{}
     ),
   ]
 }
@@ -66,12 +59,14 @@ $test::{
   description: "Ion Schema version marker must come before header if header is present.",
   invalid_schemas:[
     (
-      header::{}
+      // Technically, this is Ion Schema 1.0 because we find a header without seeing any version marker.
+      // The schema is actually invalid because of an extraneous version marker in the body of the schema.
+      schema_header::{}
       $ion_schema_2_0
       type::{
         name: foo
       }
-      footer::{}
+      schema_footer::{}
     )
   ]
 }
@@ -80,6 +75,8 @@ $test::{
   description: "Ion Schema version marker must come before any types.",
   invalid_schemas:[
     (
+      // Technically, this is Ion Schema 1.0 because we find a type without seeing any version marker.
+      // The schema is actually invalid because of an extraneous version marker in the body of the schema.
       type::{
         name: foo,
       }

--- a/ion_schema_2_0/schema/schema_footer.isl
+++ b/ion_schema_2_0/schema/schema_footer.isl
@@ -1,25 +1,25 @@
 $ion_schema_2_0
 
 $test::{
-  description: "Schema should have at most one schema footer.",
-  invalid_schemas: [
+  description: "Schema footer can optionally be present at the end of a schema",
+  valid_schemas: [
     (
-      $ion_schema_2_0
+    $ion_schema_2_0
       schema_header::{}
       type::{
         name: foo
       }
       schema_footer::{}
-      schema_footer::{}
-    )
-  ]
-}
-
-$test::{
-  description: "Schema footer must be present if header is present.",
-  invalid_schemas: [
+    ),
     (
       $ion_schema_2_0
+      type::{
+        name: foo
+      }
+      schema_footer::{}
+    ),
+    (
+    $ion_schema_2_0
       schema_header::{}
       type::{
         name: foo
@@ -29,32 +29,28 @@ $test::{
 }
 
 $test::{
-  description: "Schema footer must not be present if header is not present.",
-  invalid_schemas: [
+  description: "Everything after the schema footer has no bearing on the schema.",
+  valid_schemas: [
     (
       $ion_schema_2_0
+      schema_header::{}
       type::{
         name: foo
       }
       schema_footer::{}
-    ),
-  ]
-}
 
-$test::{
-  description: "Schema footer must come after schema header.",
-  invalid_schemas: [
+      schema_footer::{}
+    ),
     (
       $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: foo
+      }
       schema_footer::{}
+
       schema_header::{}
     ),
-  ]
-}
-
-$test::{
-  description: "Schema footer must come after any type definitions.",
-  invalid_schemas: [
     (
       $ion_schema_2_0
       schema_header::{}
@@ -62,9 +58,20 @@ $test::{
         name: foo,
       }
       schema_footer::{}
+
       type::{
         name: bar,
       }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: foo,
+      }
+      schema_footer::{}
+
+      $ion_schema_0_0
     ),
   ]
 }

--- a/ion_schema_2_0/schema/schema_header.isl
+++ b/ion_schema_2_0/schema/schema_header.isl
@@ -11,15 +11,6 @@ $test::{
         name: foo
       }
       schema_footer::{}
-    ),
-    (
-      $ion_schema_2_0
-      schema_header::{}
-      type::{
-        name: foo
-      }
-      schema_footer::{}
-      schema_header::{}
     )
   ]
 }


### PR DESCRIPTION
### Issue #, if available:

Follow up for amazon-ion/ion-schema#118

### Description of changes:

* Updates tests so that footer is optional, and so that anything can come after a footer.
* Adds some clarifying notes for the ordering of the version marker in the schema
* Fixes some test with typos.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
